### PR TITLE
feat: migrar a PostGIS y actualizar proceso de carga geoespacial

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
-DATABASE_URL=postgresql://postgres:postgres@oic-model-postgres:5432/postgres
+DATABASE_URL=postgresql://postgres:postgres@oic-model-postgis:5432/postgres
 
 # POSTGRES_USER=postgres
 # POSTGRES_PASSWORD=postgres
-# POSTGRES_HOST=oic-model-postgres
+# POSTGRES_HOST=oic-model-postgis
 # POSTGRES_PORT=5432
 # POSTGRES_DB=postgres

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Una vez que el contenedor esté en ejecución, podrás acceder al IDE en:
 ### 2. Iniciar solo el servicio de PostgreSQL
 
 ```sh
-docker-compose -p oic-api-service up oic-model-postgres
+docker-compose -p oic-api-service up oic-model-postgis
 ```
 
 Este comando:
@@ -294,7 +294,7 @@ Este comando:
 Una vez inicializado el servicio de PostgreSQL, puedes conectarte a él usando:
 
 ```sh
-docker exec -it oic-model-postgres psql -U postgres -d postgres
+docker exec -it oic-model-postgis psql -U postgres -d postgres
 ```
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,22 @@
 services:
-  oic-model-postgres:
-    image: postgres:15
-    container_name: oic-model-postgres
+  oic-model-postgis:
+    image: postgis/postgis:15-3.5
+    container_name: oic-model-postgis
     ports:
       - "5433:5432"
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-    command: ["postgres"]
     volumes:
       - oic-db-model-service:/var/lib/postgresql/data
+    networks:
+      - oic_service_network
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "postgres" ]
+      test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
-    networks:
-      - oic_service_network
 
   oic-model-api:
     # Si no se tiene la imagen, se debe construir.
@@ -27,7 +26,7 @@ services:
     image: oic-model-service
     container_name: oic-model-api
     depends_on:
-      oic-model-postgres:
+      oic-model-postgis:
         condition: service_healthy
     env_file:
       - .env
@@ -45,7 +44,7 @@ services:
       sh -c "conda run --live-stream -n oic-model-server uvicorn oic_model_server.main:app --host 0.0.0.0 --port 8000 --reload"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 10m
+      interval: 2m
       timeout: 5s
       retries: 3
       start_period: 10s
@@ -73,7 +72,7 @@ services:
     image: oic-model-service
     container_name: oic-codeserver
     depends_on:
-      oic-model-postgres:
+      oic-model-postgis:
         condition: service_healthy
     networks:
       - oic_service_network

--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,4 @@ dependencies:
   - pip
   - joblib
   - python-multipart
+  - geoalchemy2

--- a/model/regression_model.py
+++ b/model/regression_model.py
@@ -35,27 +35,14 @@ def get_postgres_engine():
     return create_engine(DATABASE_URL)
 
 
-def load_or_create_geo_data():
+def get_geo_df_houses_data():
     """
-    Crea o carga la geo data de houses_raw_data.
-    
-    :return:  GeoDataFrame con la columna `id` y `geometry`.
     """
-    shp_path = Path("data/geo/kc_houses_geo.shp")
-    
-    if shp_path.exists():
-        gdf = gpd.read_file(str(shp_path))
-    else:
-        engine = get_postgres_engine()
-        query = "SELECT * FROM houses_raw_data;"
-        df_kc_houses = pd.read_sql(query, engine)
-        geometry = [Point(xy) for xy in zip(df_kc_houses["long"], df_kc_houses["lat"])]
-        gdf = gpd.GeoDataFrame(df_kc_houses, geometry=geometry, crs="EPSG:4326")[["id", "geometry"]]
-        
-        shp_path.parent.mkdir(parents=True, exist_ok=True)
-        gdf.to_file(str(shp_path))
-            
-    return gdf
+    engine = get_postgres_engine()
+    query = "SELECT id, geometry FROM geo_houses_raw_data;"
+
+    return gpd.read_postgis(query, engine, geom_col="geometry")
+
 
 
 def get_df_houses_data():

--- a/oic_model_server/core/config.py
+++ b/oic_model_server/core/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     PROJECT_VERSION: str = "0.1.0"
     DATABASE_URL: str = os.getenv(
         "DATABASE_URL",
-        "postgresql://postgres:postgres@oic-model-postgres:5432/postgres",
+        "postgresql://postgres:postgres@oic-model-postgis:5432/postgres",
     )
 
 settings = Settings()

--- a/oic_model_server/main.py
+++ b/oic_model_server/main.py
@@ -13,7 +13,7 @@ from oic_model_server.api.routes import user_router, predict_router
 
 from oic_model_server.core.database import engine
 
-from oic_model_server.services.raw_data_service import load_house_raw_data_to_db
+from oic_model_server.services.raw_data_service import load_house_raw_data_to_db, load_geo_house_raw_data_to_db
 
 
 @asynccontextmanager
@@ -33,8 +33,14 @@ async def lifespan(app: FastAPI):
 
     try:
         load_house_raw_data_to_db("kc_house_data.csv")
+        load_geo_house_raw_data_to_db()
     except Exception as e:
-            print(f"❌ Error al cargar datos desde el CSV: {e}")
+            print(f"❌ Error al cargar datos desde el CSV o al generar la GeoData: {e}")
+            
+    try:
+        load_geo_house_raw_data_to_db()
+    except Exception as e:
+            print(f"❌ Error al cargar datos Geograficos: {e}")
 
     print("🚀 ¡OIC-MODEL-API está en funcionamiento!🚀")
     await asyncio.sleep(0)

--- a/oic_model_server/models/__init__.py
+++ b/oic_model_server/models/__init__.py
@@ -1,5 +1,5 @@
 from .user import UserTable
 from .predict import PredictTable
-from .raw_data import HouseRawDataTable
+from .raw_data import HouseRawDataTable, HouseRawGeoData
 
-__all__ = ["PredictTable", "UserTable", "HouseRawDataTable"]
+__all__ = ["PredictTable", "UserTable", "HouseRawDataTable", "HouseRawGeoData"]

--- a/oic_model_server/models/raw_data.py
+++ b/oic_model_server/models/raw_data.py
@@ -5,6 +5,8 @@ from sqlmodel import SQLModel, Field as SQLModelField
 
 from sqlalchemy import BigInteger, Column
 
+from geoalchemy2 import Geometry
+
   
 
 class HouseRawDataTable(SQLModel, table=True):
@@ -63,3 +65,17 @@ class HouseRawDataTable(SQLModel, table=True):
     long: Optional[float] = SQLModelField(default=None, nullable=True)    
     sqft_living15: Optional[int] = SQLModelField(default=None, nullable=True)
     sqft_lot15: Optional[int] = SQLModelField(default=None, nullable=True)
+
+
+class HouseRawGeoData(SQLModel, table=True):
+    """
+    Tabla para almacenar únicamente el identificador y la geometría (como POINT) de cada propiedad.
+    Esta tabla se usará para operaciones geoespaciales y modelos ML que requieran información geográfica.
+    """
+    __tablename__ = "geo_houses_raw_data"
+    
+    id: Optional[int] = SQLModelField(
+        default=None, 
+        sa_column=Column(BigInteger, primary_key=True)
+    ) 
+    geometry: Optional[str] = SQLModelField(sa_column=Column(Geometry(geometry_type='POINT', srid=4326)))


### PR DESCRIPTION
## Migrar a PostGIS y actualizar proceso de carga geoespacial

- Se sustituyen referencias de 'oic-model-postgres' a 'oic-model-postgis'
- Se integra la imagen postgis/postgis:15-3.5 en docker-compose.yml
- Se incluye la dependencia 'geoalchemy2' en environment.yml
- Se crea la tabla 'geo_houses_raw_data' con soporte para geometría (POINT)
- Se refactorizan funciones para cargar y actualizar datos geoespaciales
- Se actualiza la documentación (README) y variables de entorno (.env.example) para el nuevo servicio PostGIS